### PR TITLE
Update to Gnome 42

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.codeblocks.codeblocks.yaml
+++ b/org.codeblocks.codeblocks.yaml
@@ -10,11 +10,12 @@ finish-args:
   - --allow=devel
   - --device=dri
   - '--env=TERMINFO_DIRS=/app/share/terminfo:'
+  # wxMenu scrolling is broken on Wayland, see #11
+  - --env=GDK_BACKEND=x11
   - --filesystem=home
   - --filesystem=host
   - --share=ipc
   - --share=network
-  - --socket=fallback-x11
   - --socket=session-bus
   - --socket=ssh-auth
   - --socket=system-bus

--- a/org.codeblocks.codeblocks.yaml
+++ b/org.codeblocks.codeblocks.yaml
@@ -33,6 +33,11 @@ modules:
     config-opts:
       - --with-boost-libdir=/app/lib
       - --with-contrib-plugins=all,-FileManager,-dragscroll
+    post-install:
+      - mv ${FLATPAK_DEST}/share/mime/packages/{,org.codeblocks.}codeblocks.xml
+      - mv ${FLATPAK_DEST}/share/icons/hicolor/48x48/mimetypes/{,${FLATPAK_ID}-}application-x-codeblocks.png
+      - mv ${FLATPAK_DEST}/share/icons/hicolor/48x48/mimetypes/{,${FLATPAK_ID}-}application-x-codeblocks-workspace.png
+      - install -Dm644 codeblocks-128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/codeblocks.png
     sources:
       - type: archive
         url: https://sourceforge.net/projects/codeblocks/files/Sources/20.03/codeblocks-20.03.tar.xz
@@ -56,11 +61,6 @@ modules:
             src/plugins/contrib/appdata/Makefile.{am,in}
       - type: file
         path: codeblocks-128.png
-    post-install:
-      - mv /app/share/mime/packages/{,org.codeblocks.}codeblocks.xml
-      - mv /app/share/icons/hicolor/48x48/mimetypes/{,org.codeblocks.codeblocks-}application-x-codeblocks.png
-      - mv /app/share/icons/hicolor/48x48/mimetypes/{,org.codeblocks.codeblocks-}application-x-codeblocks-workspace.png
-      - install -Dm644 codeblocks-128.png /app/share/icons/hicolor/128x128/apps/codeblocks.png
     modules:
       - boost/boost.json
       - wxWidgets/wxWidgets.json

--- a/org.codeblocks.codeblocks.yaml
+++ b/org.codeblocks.codeblocks.yaml
@@ -34,6 +34,8 @@ modules:
       - --with-boost-libdir=/app/lib
       - --with-contrib-plugins=all,-FileManager,-dragscroll
     post-install:
+      # don't link to upstream bug tracker as the application is not endorsed by its developer
+      - sed -i '/url type="bugtracker"/d' ${FLATPAK_DEST}/share/metainfo/codeblocks.appdata.xml
       - mv ${FLATPAK_DEST}/share/mime/packages/{,org.codeblocks.}codeblocks.xml
       - mv ${FLATPAK_DEST}/share/icons/hicolor/48x48/mimetypes/{,${FLATPAK_ID}-}application-x-codeblocks.png
       - mv ${FLATPAK_DEST}/share/icons/hicolor/48x48/mimetypes/{,${FLATPAK_ID}-}application-x-codeblocks-workspace.png

--- a/org.codeblocks.codeblocks.yaml
+++ b/org.codeblocks.codeblocks.yaml
@@ -1,6 +1,6 @@
 app-id: org.codeblocks.codeblocks
 runtime: org.gnome.Sdk
-runtime-version: '41'
+runtime-version: '42'
 sdk: org.gnome.Sdk
 rename-appdata-file: codeblocks.appdata.xml
 rename-desktop-file: codeblocks.desktop

--- a/org.codeblocks.codeblocks.yaml
+++ b/org.codeblocks.codeblocks.yaml
@@ -65,5 +65,5 @@ modules:
         path: codeblocks-128.png
     modules:
       - boost/boost.json
-      - wxWidgets/wxWidgets.json
+      - wxwidgets/wxwidgets.json
   - termite/termite.json

--- a/wxwidgets/wxwidgets.json
+++ b/wxwidgets/wxwidgets.json
@@ -1,5 +1,5 @@
 {
-    "name": "wxWidgets",
+    "name": "wxwidgets",
     "sources": [
         {
             "type": "archive",


### PR DESCRIPTION
Changes:

- Update runtime to Gnome 42
- Force X11 GDK backend
- AppStream Metadata: Remove bug tracker link
- Remove unused shared-modules
- Use FLATPAK_DEST where it's possible
- Rename wxwidgets module