### PR TITLE
Add beta builds

### DIFF
--- a/org.codeblocks.codeblocks.yaml
+++ b/org.codeblocks.codeblocks.yaml
@@ -9,8 +9,6 @@ finish-args:
   - --allow=devel
   - --device=dri
   - '--env=TERMINFO_DIRS=/app/share/terminfo:'
-  # wxMenu scrolling is broken on Wayland, see #11
-  - --env=GDK_BACKEND=x11
   - --filesystem=home
   - --filesystem=host
   - --share=ipc

--- a/org.codeblocks.codeblocks.yaml
+++ b/org.codeblocks.codeblocks.yaml
@@ -39,15 +39,9 @@ modules:
       - mv ${FLATPAK_DEST}/share/icons/hicolor/48x48/mimetypes/{,${FLATPAK_ID}-}application-x-codeblocks-workspace.png
       - install -Dm644 codeblocks-128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/codeblocks.png
     sources:
-      - type: archive
-        url: https://sourceforge.net/projects/codeblocks/files/Sources/20.03/codeblocks-20.03.tar.xz
-        sha256: 15eeb3e28aea054e1f38b0c7f4671b4d4d1116fd05f63c07aa95a91db89eaac5
-        x-checker-data:
-          is-main-source: true
-          type: anitya
-          project-id: 313
-          stable-only: true
-          url-template: https://sourceforge.net/projects/codeblocks/files/Sources/$version/codeblocks-$version.tar.xz
+      - type: svn
+        url: svn://svn.code.sf.net/p/codeblocks/code/trunk
+        revision: '12794'
       - type: file
         path: org.codeblocks.codeblocks.metainfo.xml
       - type: patch
@@ -58,6 +52,7 @@ modules:
         path: codeblocks-open-txt-files-in-builtin-editor.patch
       - type: shell
         commands:
+          - ./bootstrap
           - sed -i 's|$(datadir)/pixmaps|$(datadir)/icons/hicolor/64x64/apps|' src/mime/Makefile.{am,in}
           - sed -i 's|$(datarootdir)/appdata|$(datarootdir)/metainfo|' Makefile.{am,in}
             src/plugins/contrib/appdata/Makefile.{am,in}

--- a/wxwidgets/wxwidgets.json
+++ b/wxwidgets/wxwidgets.json
@@ -3,12 +3,12 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxWidgets-3.0.5.tar.bz2",
-            "sha256": "8aacd56b462f42fb6e33b4d8f5d40be5abc3d3b41348ea968aa515cc8285d813",
+            "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxWidgets-3.1.6.tar.bz2",
+            "sha256": "4980e86c6494adcd527a41fc0a4e436777ba41d1893717d7b7176c59c2061c25",
             "x-checker-data": {
                 "type": "html",
                 "url": "https://www.wxwidgets.org/downloads",
-                "version-pattern": "Latest Stable Release: ([\\d\\.-]+)",
+                "version-pattern": "Latest Development Release: ([\\d\\.-]+)",
                 "url-template": "https://github.com/wxWidgets/wxWidgets/releases/download/v$version/wxWidgets-$version.tar.bz2"
             }
         }


### PR DESCRIPTION
This is an initial evaluation of providing a beta branch with the application built using the latest svn commit against a recent development release of the upcoming wxwidgets 3.2.  
Right now, only testing that the CI can build this
