### PR TITLE
Update runtime to Freedesktop 22.08

### DIFF
--- a/org.codeblocks.codeblocks.yaml
+++ b/org.codeblocks.codeblocks.yaml
@@ -1,6 +1,6 @@
 app-id: org.codeblocks.codeblocks
 runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 rename-desktop-file: codeblocks.desktop
 rename-icon: codeblocks
@@ -134,7 +134,7 @@ modules:
       - -Deditor_binary=/app/bin/codeblocks-bin
       - -Deditor_title=Code::Blocks IDE
       - -Dprogram_name=codeblocks
-      - -Dsdk_version=21.08
+      - -Dsdk_version=22.08
     sources:
       - type: git
         url: https://github.com/flathub/ide-flatpak-wrapper.git


### PR DESCRIPTION
Nothing else is updated, will wait for an actual release (already 2.6yo), as I'm not willing to add here patches. Beta channel will be updated later, maybe next week, as I don't have CPU cycles to spare currently to test SVN revisions locally, and I'm not going to throw them at the CI.